### PR TITLE
Compiled in debug mode.

### DIFF
--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -45,11 +45,15 @@ public:
       m_geom(geom),
       m_ma(geom,vars_old,Theta_prim,Qv_prim,z_phys_nd)
     {
+        amrex::ParmParse pp("erf");
+
         // We have a moisture model if Qv_prim is a valid pointer
         use_moisture = (Qv_prim[0].get());
 
+        // Should we store the fluxes?
+        pp.query("most.store_fluxes", m_store_fluxes);
+
         // Get roughness
-        amrex::ParmParse pp("erf");
         pp.query("most.z0", z0_const);
 
         // Specify how to compute the flux
@@ -220,26 +224,20 @@ public:
     void
     impose_most_bcs (const int& lev,
                      const amrex::Vector<amrex::MultiFab*>& mfs,
-#ifdef ERF_EXPLICIT_MOST_STRESS
                      amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
                      amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
-                     amrex::MultiFab* heat_flux,
-#else
+                     amrex::MultiFab* heat_flux,  amrex::MultiFab* qv_flux,
                      amrex::MultiFab* eddyDiffs,
-#endif
                      amrex::MultiFab* z_phys);
 
     template<typename FluxCalc>
     void
     compute_most_bcs (const int& lev,
                       const amrex::Vector<amrex::MultiFab*>& mfs,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                     amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
-                     amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
-                      amrex::MultiFab* heat_flux,
-#else
+                      amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
+                      amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
+                      amrex::MultiFab* heat_flux,  amrex::MultiFab* qv_flux,
                       amrex::MultiFab* eddyDiffs,
-#endif
                       amrex::MultiFab* z_phys,
                       const amrex::Real& dz_no_terrain,
                       const FluxCalc& flux_comp);
@@ -286,6 +284,9 @@ public:
     const amrex::MultiFab*
     get_mac_avg (const int& lev, int comp) { return m_ma.get_average(lev,comp); }
 
+    bool
+    store_fluxes() { return m_store_fluxes; }
+
     enum struct FluxCalcType {
         MOENG = 0,      ///< Moeng functional form
         DONELAN,        ///< Donelan functional form
@@ -310,6 +311,7 @@ public:
 
 private:
     bool use_moisture;
+    bool m_store_fluxes{false};
     amrex::Real z0_const;
     amrex::Real surf_temp;
     amrex::Real surf_heating_rate{0};

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -321,13 +321,10 @@ ERF::FillIntermediatePatch (int lev, Real time,
     // MOST boundary conditions
     if (!(cons_only && ncomp_cons == 1) && m_most && allow_most_bcs) {
         m_most->impose_most_bcs(lev,mfs_vel,
-#ifdef ERF_EXPLICIT_MOST_STRESS
                                 Tau13_lev[lev].get(), Tau31_lev[lev].get(),
                                 Tau23_lev[lev].get(), Tau32_lev[lev].get(),
-                                SFS_hfx3_lev[lev].get(),
-#else
+                                SFS_hfx3_lev[lev].get(), SFS_qfx3_lev[lev].get(),
                                 eddyDiffs_lev[lev].get(),
-#endif
                                 z_phys_nd[lev].get());
     }
 

--- a/Source/BoundaryConditions/MOSTStress.H
+++ b/Source/BoundaryConditions/MOSTStress.H
@@ -587,65 +587,28 @@ private:
  */
 struct moeng_flux
 {
-    moeng_flux (int l_zlo)
-      :  zlo(l_zlo) {}
+    moeng_flux (int l_klo)
+      :  klo(l_klo) {}
 
 
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real
-    compute_q_flux (const int& i,
-                    const int& j,
-                    const int& k,
-                    const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
-                    const amrex::Array4<const amrex::Real>& cons_arr,
+    compute_q_flux (const int& /*i*/,
+                    const int& /*j*/,
+                    const int& /*k*/,
+                    const int& /*n*/,
+                    const amrex::Array4<const amrex::Real>& /*cons_arr*/,
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*tm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& /*q_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
     {
-        amrex::Real rho, eta, qv;
-
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
-        int ic, jc;
-        ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
-        jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
-        ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
-        jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
-
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        qv    = cons_arr(ic,jc,zlo,RhoQ1_comp) / rho;
-
-        // TODO: Integrate MOST with moisture and MOENG FLUX type
+        // TODO: Integrate MOST with moisture and DONELAN FLUX type
         amrex::Real moflux  = 0.0;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        amrex::Abort("Explicit MOST stress not implemented for Moeng moisture flux");
-#else
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -655,82 +618,51 @@ struct moeng_flux
     amrex::Real
     compute_t_flux (const int& i,
                     const int& j,
-                    const int& k,
+                    const int& /*k*/,
                     const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& tm_arr,
                     const amrex::Array4<const amrex::Real>& u_star_arr,
                     const amrex::Array4<const amrex::Real>& t_star_arr,
-                    const amrex::Array4<const amrex::Real>& t_surf_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& t_surf_arr) const
     {
-        amrex::Real velx, vely, rho, theta, eta;
-        int ix, jx, iy, jy, ic, jc;
-
+        int ix, jx;
         ix = i < lbound(velx_arr).x    ? lbound(velx_arr).x   : i;
         jx = j < lbound(velx_arr).y    ? lbound(velx_arr).y   : j;
         ix = ix > ubound(velx_arr).x-1 ? ubound(velx_arr).x-1 : ix;
         jx = jx > ubound(velx_arr).y   ? ubound(velx_arr).y   : jx;
 
+        int iy, jy;
         iy = i  < lbound(vely_arr).x   ? lbound(vely_arr).x   : i;
         jy = j  < lbound(vely_arr).y   ? lbound(vely_arr).y   : j;
         iy = iy > ubound(vely_arr).x   ? ubound(vely_arr).x   : iy;
         jy = jy > ubound(vely_arr).y-1 ? ubound(vely_arr).y-1 : jy;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
+        int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
         jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
         ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
-        velx  = 0.5 *( velx_arr(ix,jx,zlo) + velx_arr(ix+1,jx  ,zlo) );
-        vely  = 0.5 *( vely_arr(iy,jy,zlo) + vely_arr(iy  ,jy+1,zlo) );
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
+        amrex::Real velx  = 0.5 *( velx_arr(ix,jx,klo) + velx_arr(ix+1,jx  ,klo) );
+        amrex::Real vely  = 0.5 *( vely_arr(iy,jy,klo) + vely_arr(iy  ,jy+1,klo) );
+        amrex::Real rho   = cons_arr(ic,jc,klo,Rho_comp);
+        amrex::Real theta = cons_arr(ic,jc,klo,n) / rho;
 
-        amrex::Real theta_mean  = tm_arr(ic,jc,zlo);
-        amrex::Real wsp_mean    = umm_arr(ic,jc,zlo);
-        amrex::Real ustar       = u_star_arr(ic,jc,zlo);
-        amrex::Real tstar       = t_star_arr(ic,jc,zlo);
-        amrex::Real theta_surf  = t_surf_arr(ic,jc,zlo);
+        amrex::Real theta_mean  = tm_arr(ic,jc,klo);
+        amrex::Real wsp_mean    = umm_arr(ic,jc,klo);
+        amrex::Real ustar       = u_star_arr(ic,jc,klo);
+        amrex::Real tstar       = t_star_arr(ic,jc,klo);
+        amrex::Real theta_surf  = t_surf_arr(ic,jc,klo);
 
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real num1    = wsp * (theta_mean-theta_surf);
         amrex::Real num2    = wsp_mean * (theta-theta_mean);
         amrex::Real moflux  = (std::abs(tstar) > eps) ?
                               -tstar*ustar*(num1+num2)/((theta_mean-theta_surf)*wsp_mean) : 0.0;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real thetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - thetagrad * deltaz;
-#else
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        // Note: Kh = eta/rho
-        //      hfx = -Kh dT/dz  ==> +ve hfx corresponds to heating from the surface
-        // Extrapolate from klo to ghost cell a distance of -deltaz; negative signs cancel
-        dest_arr(i,j,k,icomp+n) = rho*(theta + moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -740,54 +672,36 @@ struct moeng_flux
     amrex::Real
     compute_u_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& um_arr,
-                    const amrex::Array4<const amrex::Real>& u_star_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& u_star_arr) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int jy, ic, jc;
-
         int iylo = i <= lbound(vely_arr).x ? lbound(vely_arr).x : i-1;
         int iyhi = i >  ubound(vely_arr).x ? ubound(vely_arr).x : i;
 
+        int jy;
         jy = j  < lbound(vely_arr).y   ? lbound(vely_arr).y   : j;
         jy = jy > ubound(vely_arr).y-1 ? ubound(vely_arr).y-1 : jy;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x+1 ? lbound(eta_arr).x+1 : i;
-        je = j  < lbound(eta_arr).y   ? lbound(eta_arr).y   : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
-
+        int ic, jc;
         ic = i  < lbound(cons_arr).x+1 ? lbound(cons_arr).x+1 : i;
         jc = j  < lbound(cons_arr).y   ? lbound(cons_arr).y   : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = velx_arr(i,j,zlo);
-        vely  = 0.25*( vely_arr(iyhi,jy,zlo)+vely_arr(iyhi,jy+1,zlo)
-                     + vely_arr(iylo,jy,zlo)+vely_arr(iylo,jy+1,zlo) );
-        rho   = 0.5 *( cons_arr(ic-1,jc,zlo,Rho_comp)
-                     + cons_arr(ic  ,jc,zlo,Rho_comp) );
+        amrex::Real velx  = velx_arr(i,j,klo);
+        amrex::Real vely  = 0.25*( vely_arr(iyhi,jy,klo)+vely_arr(iyhi,jy+1,klo)
+                                 + vely_arr(iylo,jy,klo)+vely_arr(iylo,jy+1,klo) );
+        amrex::Real rho   = 0.5 *( cons_arr(ic-1,jc,klo,Rho_comp)
+                                 + cons_arr(ic  ,jc,klo,Rho_comp) );
 
-        amrex::Real umean    = um_arr(i,j,zlo);
-        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic-1,jc,zlo) + umm_arr(ic,jc,zlo) );
-        amrex::Real ustar    = 0.5 * ( u_star_arr(ic-1,jc,zlo) + u_star_arr(ic,jc,zlo) );
+        amrex::Real umean    = um_arr(i,j,klo);
+        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic-1,jc,klo) + umm_arr(ic,jc,klo) );
+        amrex::Real ustar    = 0.5 * ( u_star_arr(ic-1,jc,klo) + u_star_arr(ic,jc,klo) );
 
         // Note: The surface mean shear stress is decomposed into tau_xz by
         //       multiplying the modeled shear stress (rho*ustar^2) with
@@ -797,18 +711,6 @@ struct moeng_flux
         amrex::Real num1    = wsp * umean;
         amrex::Real num2    = wsp_mean * (velx-umean);
         amrex::Real stressx = rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real ugrad = (velx_arr(i,j,zlo+1) - velx) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(velx - ugrad * deltaz);
-#else
-        eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
-                      + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
-#endif
 
         return stressx;
     }
@@ -818,54 +720,36 @@ struct moeng_flux
     amrex::Real
     compute_v_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& vm_arr,
-                    const amrex::Array4<const amrex::Real>& u_star_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& u_star_arr) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int ix, ic, jc;
-
-        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
-        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
-
         int jxlo = j <= lbound(velx_arr).y ? lbound(velx_arr).y : j-1;
         int jxhi = j >  ubound(velx_arr).y ? ubound(velx_arr).y : j;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x   ? lbound(eta_arr).x   : i;
-        je = j  < lbound(eta_arr).y+1 ? lbound(eta_arr).y+1 : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
+        int ix;
+        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
+        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
 
+        int ic, jc;
         ic = i  < lbound(cons_arr).x   ? lbound(cons_arr).x   : i;
         jc = j  < lbound(cons_arr).y+1 ? lbound(cons_arr).y+1 : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = 0.25*( velx_arr(ix,jxhi,zlo)+velx_arr(ix+1,jxhi,zlo)
-                     + velx_arr(ix,jxlo,zlo)+velx_arr(ix+1,jxlo,zlo) );
-        vely  = vely_arr(i,j,zlo);
-        rho   = 0.5*( cons_arr(ic,jc-1,zlo,Rho_comp)
-                    + cons_arr(ic,jc  ,zlo,Rho_comp) );
+        amrex::Real velx  = 0.25*( velx_arr(ix,jxhi,klo)+velx_arr(ix+1,jxhi,klo)
+                                 + velx_arr(ix,jxlo,klo)+velx_arr(ix+1,jxlo,klo) );
+        amrex::Real vely  = vely_arr(i,j,klo);
+        amrex::Real rho   = 0.5*( cons_arr(ic,jc-1,klo,Rho_comp)
+                                + cons_arr(ic,jc  ,klo,Rho_comp) );
 
-        amrex::Real vmean     = vm_arr(i,j,zlo);
-        amrex::Real wsp_mean  = 0.5 * ( umm_arr(ic,jc-1,zlo) + umm_arr(ic,jc,zlo) );
-        amrex::Real ustar     = 0.5 * ( u_star_arr(ic,jc-1,zlo) + u_star_arr(ic,jc,zlo) );
+        amrex::Real vmean     = vm_arr(i,j,klo);
+        amrex::Real wsp_mean  = 0.5 * ( umm_arr(ic,jc-1,klo) + umm_arr(ic,jc,klo) );
+        amrex::Real ustar     = 0.5 * ( u_star_arr(ic,jc-1,klo) + u_star_arr(ic,jc,klo) );
 
         // Note: The surface mean shear stress is decomposed into tau_yz by
         //       multiplying the modeled shear stress (rho*ustar^2) with
@@ -875,26 +759,13 @@ struct moeng_flux
         amrex::Real num1    = wsp * vmean;
         amrex::Real num2    = wsp_mean * (vely-vmean);
         amrex::Real stressy = rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real vgrad = (vely_arr(i,j,zlo+1) - vely) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(vely - vgrad * deltaz);
-#else
-        eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
-                     + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
-#endif
 
         return stressy;
     }
 
 private:
-    int zlo;
+    int klo;
     const amrex::Real     eps = 1e-15;
-    const amrex::Real eta_eps = 1e-8;
 };
 
 
@@ -903,65 +774,28 @@ private:
  */
 struct donelan_flux
 {
-    donelan_flux (int l_zlo)
-      :  zlo(l_zlo) {}
+    donelan_flux (int l_klo)
+      :  klo(l_klo) {}
 
 
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real
-    compute_q_flux (const int& i,
-                    const int& j,
-                    const int& k,
-                    const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
-                    const amrex::Array4<const amrex::Real>& cons_arr,
+    compute_q_flux (const int& /*i*/,
+                    const int& /*j*/,
+                    const int& /*k*/,
+                    const int& /*n*/,
+                    const amrex::Array4<const amrex::Real>& /*cons_arr*/,
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*tm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& /*q_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
     {
-        amrex::Real rho, eta, qv;
-
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
-        int ic, jc;
-        ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
-        jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
-        ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
-        jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
-
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        qv    = cons_arr(ic,jc,zlo,RhoQ1_comp) / rho;
-
         // TODO: Integrate MOST with moisture and DONELAN FLUX type
         amrex::Real moflux  = 0.0;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        amrex::Abort("Explicit MOST stress not implemented for Donelan moisture flux");
-#else
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -971,64 +805,28 @@ struct donelan_flux
     amrex::Real
     compute_t_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
+                    const int& /*n*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& tm_arr,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& /*t_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& t_surf_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& t_surf_arr) const
     {
-        amrex::Real rho, theta, eta;
-
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
         jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
         ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
-
         amrex::Real Cd = 0.0012;
-        amrex::Real wsp_mean    = umm_arr(ic,jc,zlo);
-        amrex::Real theta_surf  = t_surf_arr(ic,jc,zlo);
-        amrex::Real theta_mean  = tm_arr(ic,jc,zlo);
+        amrex::Real wsp_mean    = umm_arr(ic,jc,klo);
+        amrex::Real theta_surf  = t_surf_arr(ic,jc,klo);
+        amrex::Real theta_mean  = tm_arr(ic,jc,klo);
         amrex::Real moflux      = Cd * wsp_mean * (theta_surf - theta_mean);
-        amrex::Real deltaz      = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real thetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - thetagrad * deltaz;
-#else
-        eta   =  eta_arr(ie,je,zlo,EddyDiff::Theta_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        // Note: Kh = eta/rho
-        //      hfx = -Kh dT/dz  ==> +ve hfx corresponds to heating from the surface
-        // Extrapolate from klo to ghost cell a distance of -deltaz; negative signs cancel
-        dest_arr(i,j,k,icomp+n) = rho*(theta + moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -1038,55 +836,37 @@ struct donelan_flux
     amrex::Real
     compute_u_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& /*um_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*u_star_arr*/) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int jy, ic, jc;
-
         int iylo = i <= lbound(vely_arr).x ? lbound(vely_arr).x : i-1;
         int iyhi = i >  ubound(vely_arr).x ? ubound(vely_arr).x : i;
 
+        int jy;
         jy = j  < lbound(vely_arr).y   ? lbound(vely_arr).y   : j;
         jy = jy > ubound(vely_arr).y-1 ? ubound(vely_arr).y-1 : jy;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x+1 ? lbound(eta_arr).x+1 : i;
-        je = j  < lbound(eta_arr).y   ? lbound(eta_arr).y   : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
-
+        int ic, jc;
         ic = i  < lbound(cons_arr).x+1 ? lbound(cons_arr).x+1 : i;
         jc = j  < lbound(cons_arr).y   ? lbound(cons_arr).y   : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = velx_arr(i,j,zlo);
-        vely  = 0.25*( vely_arr(iyhi,jy,zlo)+vely_arr(iyhi,jy+1,zlo)
-                     + vely_arr(iylo,jy,zlo)+vely_arr(iylo,jy+1,zlo) );
-        rho   = 0.5 *( cons_arr(ic-1,jc,zlo,Rho_comp)
-                     + cons_arr(ic  ,jc,zlo,Rho_comp) );
+        amrex::Real velx  = velx_arr(i,j,klo);
+        amrex::Real vely  = 0.25*( vely_arr(iyhi,jy,klo)+vely_arr(iyhi,jy+1,klo)
+                                 + vely_arr(iylo,jy,klo)+vely_arr(iylo,jy+1,klo) );
+        amrex::Real rho   = 0.5 *( cons_arr(ic-1,jc,klo,Rho_comp)
+                                 + cons_arr(ic  ,jc,klo,Rho_comp) );
 
         amrex::Real Cd       = 0.001;
         const amrex::Real c  = 7e-5;
         amrex::Real wsp      = sqrt(velx*velx+vely*vely);
-        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic-1,jc,zlo) + umm_arr(ic,jc,zlo) );
+        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic-1,jc,klo) + umm_arr(ic,jc,klo) );
         if (wsp_mean <= 5.0) {
             Cd = 0.001;
         } else if (wsp_mean < 25.0 && wsp_mean > 5.0) {
@@ -1095,18 +875,6 @@ struct donelan_flux
             Cd = 0.0024;
         }
         amrex::Real stressx = rho * Cd * velx * wsp;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real ugrad = (velx_arr(i,j,zlo+1) - velx) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(velx - ugrad * deltaz);
-#else
-        eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
-                      + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
-#endif
 
         return stressx;
     }
@@ -1116,55 +884,37 @@ struct donelan_flux
     amrex::Real
     compute_v_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& umm_arr,
                     const amrex::Array4<const amrex::Real>& /*vm_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*u_star_arr*/) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int ix, ic, jc;
-
-        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
-        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
-
         int jxlo = j <= lbound(velx_arr).y ? lbound(velx_arr).y : j-1;
         int jxhi = j >  ubound(velx_arr).y ? ubound(velx_arr).y : j;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x   ? lbound(eta_arr).x   : i;
-        je = j  < lbound(eta_arr).y+1 ? lbound(eta_arr).y+1 : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
+        int ix;
+        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
+        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
 
+        int ic, jc;
         ic = i  < lbound(cons_arr).x   ? lbound(cons_arr).x   : i;
         jc = j  < lbound(cons_arr).y+1 ? lbound(cons_arr).y+1 : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = 0.25*( velx_arr(ix,jxhi,zlo)+velx_arr(ix+1,jxhi,zlo)
-                     + velx_arr(ix,jxlo,zlo)+velx_arr(ix+1,jxlo,zlo) );
-        vely  = vely_arr(i,j,zlo);
-        rho   = 0.5*( cons_arr(ic,jc-1,zlo,Rho_comp)
-                    + cons_arr(ic,jc  ,zlo,Rho_comp) );
+        amrex::Real velx  = 0.25*( velx_arr(ix,jxhi,klo)+velx_arr(ix+1,jxhi,klo)
+                                 + velx_arr(ix,jxlo,klo)+velx_arr(ix+1,jxlo,klo) );
+        amrex::Real vely  = vely_arr(i,j,klo);
+        amrex::Real rho   = 0.5*( cons_arr(ic,jc-1,klo,Rho_comp)
+                                + cons_arr(ic,jc  ,klo,Rho_comp) );
 
         amrex::Real Cd       = 0.001;
         const amrex::Real c  = 7e-5;
         amrex::Real wsp      = sqrt(velx*velx+vely*vely);
-        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic,jc-1,zlo) + umm_arr(ic,jc,zlo) );
+        amrex::Real wsp_mean = 0.5 * ( umm_arr(ic,jc-1,klo) + umm_arr(ic,jc,klo) );
         if (wsp_mean <= 5.0) {
             Cd = 0.001;
         } else if (wsp_mean < 25.0 && wsp_mean > 5.0) {
@@ -1173,25 +923,12 @@ struct donelan_flux
             Cd = 0.0024;
         }
         amrex::Real stressy = rho * Cd * vely * wsp;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real vgrad = (vely_arr(i,j,zlo+1) - vely) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(vely - vgrad * deltaz);
-#else
-        eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
-                     + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
-#endif
 
         return stressy;
     }
 
 private:
-    int zlo;
-    const amrex::Real eta_eps = 1e-8;
+    int klo;
 };
 
 
@@ -1200,8 +937,8 @@ private:
  */
 struct custom_flux
 {
-    custom_flux (int l_zlo)
-      :  zlo(l_zlo) {}
+    custom_flux (int l_klo)
+      :  klo(l_klo) {}
 
 
     AMREX_GPU_DEVICE
@@ -1209,56 +946,27 @@ struct custom_flux
     amrex::Real
     compute_q_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
+                    const int& /*n*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*tm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& q_star_arr,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
     {
-        amrex::Real rho, eta, qv;
-
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
         jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
         ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        qv    = cons_arr(ic,jc,zlo,RhoQ1_comp) / rho;
+        amrex::Real rho = cons_arr(ic,jc,klo,Rho_comp);
 
-        amrex::Real qstar   = q_star_arr(ic,jc,zlo);
+        amrex::Real qstar   = q_star_arr(ic,jc,klo);
         amrex::Real moflux  = (std::abs(qstar) > eps) ? -rho * qstar : 0.0;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        amrex::Abort("Explicit MOST stress not implemented for custom moisture flux");
-#else
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -1268,62 +976,26 @@ struct custom_flux
     amrex::Real
     compute_t_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& n,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
+                    const int& /*n*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*tm_arr*/,
                     const amrex::Array4<const amrex::Real>& u_star_arr,
                     const amrex::Array4<const amrex::Real>& t_star_arr,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
     {
-        amrex::Real rho, eta, theta;
-
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-#endif
-
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
         jc = j  < lbound(cons_arr).y ? lbound(cons_arr).y : j;
         ic = ic > ubound(cons_arr).x ? ubound(cons_arr).x : ic;
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
-        rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
-
-        amrex::Real ustar   = u_star_arr(ic,jc,zlo);
-        amrex::Real tstar   = t_star_arr(ic,jc,zlo);
+        amrex::Real ustar   = u_star_arr(ic,jc,klo);
+        amrex::Real tstar   = t_star_arr(ic,jc,klo);
         amrex::Real moflux  = (std::abs(tstar) > eps) ? -tstar*ustar : 0.0;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real thetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - thetagrad * deltaz;
-#else
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        // Note: Kh = eta/rho
-        //      hfx = -Kh dT/dz  ==> +ve hfx corresponds to heating from the surface
-        // Extrapolate from klo to ghost cell a distance of -deltaz; negative signs cancel
-        dest_arr(i,j,k,icomp+n) = rho*(theta + moflux*rho/eta*deltaz);
-#endif
 
         return moflux;
     }
@@ -1333,66 +1005,36 @@ struct custom_flux
     amrex::Real
     compute_u_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*um_arr*/,
-                    const amrex::Array4<const amrex::Real>& u_star_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& u_star_arr) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int jy, ic, jc;
-
         int iylo = i <= lbound(vely_arr).x ? lbound(vely_arr).x : i-1;
         int iyhi = i >  ubound(vely_arr).x ? ubound(vely_arr).x : i;
 
+        int jy;
         jy = j  < lbound(vely_arr).y   ? lbound(vely_arr).y   : j;
         jy = jy > ubound(vely_arr).y-1 ? ubound(vely_arr).y-1 : jy;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x+1 ? lbound(eta_arr).x+1 : i;
-        je = j  < lbound(eta_arr).y   ? lbound(eta_arr).y   : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
-
+        int ic, jc;
         ic = i  < lbound(cons_arr).x+1 ? lbound(cons_arr).x+1 : i;
         jc = j  < lbound(cons_arr).y   ? lbound(cons_arr).y   : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = velx_arr(i,j,zlo);
-        vely  = 0.25*( vely_arr(iyhi,jy,zlo)+vely_arr(iyhi,jy+1,zlo)
-                     + vely_arr(iylo,jy,zlo)+vely_arr(iylo,jy+1,zlo) );
-        rho   = 0.5 *( cons_arr(ic-1,jc,zlo,Rho_comp)
-                     + cons_arr(ic  ,jc,zlo,Rho_comp) );
+        amrex::Real velx  = velx_arr(i,j,klo);
+        amrex::Real vely  = 0.25*( vely_arr(iyhi,jy,klo)+vely_arr(iyhi,jy+1,klo)
+                                 + vely_arr(iylo,jy,klo)+vely_arr(iylo,jy+1,klo) );
+        amrex::Real rho   = 0.5 *( cons_arr(ic-1,jc,klo,Rho_comp)
+                                 + cons_arr(ic  ,jc,klo,Rho_comp) );
 
-        amrex::Real ustar   = 0.5 * ( u_star_arr(ic-1,jc,zlo) + u_star_arr(ic,jc,zlo) );
+        amrex::Real ustar   = 0.5 * ( u_star_arr(ic-1,jc,klo) + u_star_arr(ic,jc,klo) );
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real stressx = rho * ustar * ustar * velx / wsp;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real ugrad = (velx_arr(i,j,zlo+1) - velx) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(velx - ugrad * deltaz);
-#else
-        eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
-                      + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
-#endif
 
         return stressx;
     }
@@ -1402,73 +1044,42 @@ struct custom_flux
     amrex::Real
     compute_v_flux (const int& i,
                     const int& j,
-                    const int& k,
-                    const int& icomp,
-                    const amrex::Real& dz,
-#ifdef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Real& dz1,
-#endif
+                    const int& /*k*/,
                     const amrex::Array4<const amrex::Real>& cons_arr,
                     const amrex::Array4<const amrex::Real>& velx_arr,
                     const amrex::Array4<const amrex::Real>& vely_arr,
-#ifndef ERF_EXPLICIT_MOST_STRESS
-                    const amrex::Array4<const amrex::Real>& eta_arr,
-#endif
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vm_arr*/,
-                    const amrex::Array4<const amrex::Real>& u_star_arr,
-                    const amrex::Array4<amrex::Real>& dest_arr) const
+                    const amrex::Array4<const amrex::Real>& u_star_arr) const
     {
-        amrex::Real velx, vely, rho, eta;
-        int ix, ic, jc;
-
-        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
-        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
-
         int jxlo = j <= lbound(velx_arr).y ? lbound(velx_arr).y : j-1;
         int jxhi = j >  ubound(velx_arr).y ? ubound(velx_arr).y : j;
 
-#ifndef ERF_EXPLICIT_MOST_STRESS
-        int ie, je;
-        ie = i  < lbound(eta_arr).x   ? lbound(eta_arr).x   : i;
-        je = j  < lbound(eta_arr).y+1 ? lbound(eta_arr).y+1 : j;
-        ie = ie > ubound(eta_arr).x   ? ubound(eta_arr).x   : ie;
-        je = je > ubound(eta_arr).y   ? ubound(eta_arr).y   : je;
-#endif
+        int ix;
+        ix = i  < lbound(velx_arr).x ? lbound(velx_arr).x : i;
+        ix = ix > ubound(velx_arr).x ? ubound(velx_arr).x : ix;
 
+        int ic, jc;
         ic = i  < lbound(cons_arr).x   ? lbound(cons_arr).x   : i;
         jc = j  < lbound(cons_arr).y+1 ? lbound(cons_arr).y+1 : j;
         ic = ic > ubound(cons_arr).x   ? ubound(cons_arr).x   : ic;
         jc = jc > ubound(cons_arr).y   ? ubound(cons_arr).y   : jc;
 
-        velx  = 0.25*( velx_arr(ix,jxhi,zlo)+velx_arr(ix+1,jxhi,zlo)
-                     + velx_arr(ix,jxlo,zlo)+velx_arr(ix+1,jxlo,zlo) );
-        vely  = vely_arr(i,j,zlo);
-        rho   = 0.5*( cons_arr(ic,jc-1,zlo,Rho_comp)
-                    + cons_arr(ic,jc  ,zlo,Rho_comp) );
+        amrex::Real velx  = 0.25*( velx_arr(ix,jxhi,klo)+velx_arr(ix+1,jxhi,klo)
+                                 + velx_arr(ix,jxlo,klo)+velx_arr(ix+1,jxlo,klo) );
+        amrex::Real vely  = vely_arr(i,j,klo);
+        amrex::Real rho   = 0.5*( cons_arr(ic,jc-1,klo,Rho_comp)
+                                + cons_arr(ic,jc  ,klo,Rho_comp) );
 
-        amrex::Real ustar   = 0.5 * ( u_star_arr(ic,jc-1,zlo) + u_star_arr(ic,jc,zlo) );
+        amrex::Real ustar   = 0.5 * ( u_star_arr(ic,jc-1,klo) + u_star_arr(ic,jc,klo) );
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real stressy = rho * ustar * ustar * vely / wsp;
-        amrex::Real deltaz  = dz * (zlo - k);
-
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        // surface gradient equal to gradient at first zface
-        amrex::Real vgrad = (vely_arr(i,j,zlo+1) - vely) / (0.5*(dz+dz1));
-        dest_arr(i,j,k,icomp) = rho*(vely - vgrad * deltaz);
-#else
-        eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
-                     + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
-#endif
 
         return stressy;
     }
 
 private:
-    int zlo;
-    const amrex::Real     eps = 1e-15;
-    const amrex::Real eta_eps = 1e-8;
+    int klo;
+    const amrex::Real eps = 1e-15;
 };
 #endif

--- a/Source/Diffusion/Diffusion.H
+++ b/Source/Diffusion/Diffusion.H
@@ -63,7 +63,7 @@ void DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
                              const amrex::Array4<const amrex::Real>& tm_arr,
                              const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                              const amrex::BCRec* bc_ptr,
-                             const bool use_most);
+                             const bool store_most_stress);
 
 void DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
                              int start_comp, int num_comp,
@@ -90,7 +90,7 @@ void DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
                              const amrex::Array4<const amrex::Real>& tm_arr,
                              const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                              const amrex::BCRec* bc_ptr,
-                             const bool use_most);
+                             const bool store_most_stress);
 
 
 

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -58,7 +58,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
                         const Array4<const Real>& tm_arr,
                         const amrex::GpuArray<Real,AMREX_SPACEDIM> grav_gpu,
                         const amrex::BCRec* bc_ptr,
-                        const bool use_most)
+                        const bool store_most_stress)
 {
     BL_PROFILE_VAR("DiffusionSrcForState_N()",DiffusionSrcForState_N);
 
@@ -220,12 +220,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
 
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
@@ -275,12 +270,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
 
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
@@ -328,12 +318,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
 
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
@@ -378,12 +363,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
 
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -63,7 +63,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
                         const Array4<const Real>& tm_arr,
                         const amrex::GpuArray<Real,AMREX_SPACEDIM> grav_gpu,
                         const amrex::BCRec* bc_ptr,
-                        const bool use_most)
+                        const bool store_most_stress)
 {
     BL_PROFILE_VAR("DiffusionSrcForState_T()",DiffusionSrcForState_T);
 
@@ -247,12 +247,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
             Real GradCz;
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                         + 3. * cell_prim(i, j, k  , prim_index)
@@ -328,12 +323,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
             Real GradCz;
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                         + 3. * cell_prim(i, j, k  , prim_index)
@@ -406,12 +396,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
             Real GradCz;
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                         + 3. * cell_prim(i, j, k  , prim_index)
@@ -480,12 +465,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
             Real GradCz;
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z+1);
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            bool most_on_zlo    = ( use_most &&
-                                    (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
-#else
-            bool most_on_zlo    = false;
-#endif
+            bool most_on_zlo    = ( store_most_stress && k == 0);
             if (ext_dir_on_zlo) {
                 GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                         + 3. * cell_prim(i, j, k  , prim_index)

--- a/Source/Diffusion/EddyViscosity.H
+++ b/Source/Diffusion/EddyViscosity.H
@@ -42,7 +42,6 @@ ComputeSmnSmn (int& i, int& j, int& k,
                                 + tau12(i+1, j  , k  ) + tau12(i+1, j+1, k  ) );
 
     amrex::Real s13bar;
-#ifndef ERF_EXPLICIT_MOST_STRESS
     // NOTE: We cannot use the strains lying on the bottom boundary with MOST.
     //       These values are corrupted with the reflect odd BC used to fill
     //       the ghost cells. We use one-sided for this case.
@@ -50,23 +49,16 @@ ComputeSmnSmn (int& i, int& j, int& k,
         s13bar = 0.5  * ( tau13(i  , j  , k+1) + tau13(i+1, j  , k+1) );
     }
     else
-#endif
-    // NOTE 2: If we are using the ERF_EXPLICIT_MOST_STRESS solver path,
-    //      however, then the tau13 and tau23 surface stresses are valid and
-    //      have been set to the exact values from MOST. The one-sided calc
-    //      is therefore not needed.
     {
         s13bar = 0.25 * ( tau13(i  , j  , k  ) + tau13(i  , j  , k+1)
                         + tau13(i+1, j  , k  ) + tau13(i+1, j  , k+1) );
     }
 
     amrex::Real s23bar;
-#ifndef ERF_EXPLICIT_MOST_STRESS
     if (use_most && k==klo) {
         s23bar = 0.5  * ( tau23(i  , j  , k+1) + tau23(i  , j+1, k+1) );
     }
     else
-#endif
     {
         s23bar = 0.25 * ( tau23(i  , j  , k  ) + tau23(i  , j  , k+1)
                         + tau23(i  , j+1, k  ) + tau23(i  , j+1, k+1) );

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -591,6 +591,7 @@ private:
     // Other SFS terms
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> SFS_hfx1_lev, SFS_hfx2_lev, SFS_hfx3_lev;
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> SFS_diss_lev;
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> SFS_qfx3_lev;
 
     // Terrain / grid stretching
     amrex::Vector<amrex::Real> zlevels_stag; // nominal height levels

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -205,6 +205,7 @@ ERF::ERF ()
     Tau23_lev.resize(nlevs_max); Tau32_lev.resize(nlevs_max);
     SFS_hfx1_lev.resize(nlevs_max); SFS_hfx2_lev.resize(nlevs_max); SFS_hfx3_lev.resize(nlevs_max);
     SFS_diss_lev.resize(nlevs_max);
+    SFS_qfx3_lev.resize(nlevs_max);
     eddyDiffs_lev.resize(nlevs_max);
     SmnSmn_lev.resize(nlevs_max);
 
@@ -755,10 +756,6 @@ ERF::InitData ()
     //       FillPatch does not call MOST, FillIntermediatePatch does.
     if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::MOST)
     {
-#ifdef ERF_EXPLICIT_MOST_STRESS
-        amrex::Print() << "Using MOST with explicitly included surface stresses" << std::endl;
-#endif
-
         m_most = std::make_unique<ABLMost>(geom, vars_old, Theta_prim, Qv_prim, z_phys_nd,
                                            sst_lev, lmask_lev, lsm_data, lsm_flux
 #ifdef ERF_USE_NETCDF
@@ -1674,6 +1671,7 @@ ERF::ERF (const amrex::RealBox& rb, int max_level_in,
     Tau23_lev.resize(nlevs_max); Tau32_lev.resize(nlevs_max);
     SFS_hfx1_lev.resize(nlevs_max); SFS_hfx2_lev.resize(nlevs_max); SFS_hfx3_lev.resize(nlevs_max);
     SFS_diss_lev.resize(nlevs_max);
+    SFS_qfx3_lev.resize(nlevs_max);
     eddyDiffs_lev.resize(nlevs_max);
     SmnSmn_lev.resize(nlevs_max);
 

--- a/Source/ERF_make_new_level.cpp
+++ b/Source/ERF_make_new_level.cpp
@@ -462,6 +462,12 @@ ERF::update_diffusive_arrays (int lev, const BoxArray& ba, const DistributionMap
         SFS_hfx2_lev[lev]->setVal(0.);
         SFS_hfx3_lev[lev]->setVal(0.);
         SFS_diss_lev[lev]->setVal(0.);
+        if (solverChoice.moisture_type != MoistureType::None) {
+            SFS_qfx3_lev[lev] = std::make_unique<MultiFab>( ba  , dm, 1, IntVect(1,1,0) );
+            SFS_qfx3_lev[lev]->setVal(0.);
+        } else {
+            SFS_qfx3_lev[lev] = nullptr;
+        }
     } else {
         Tau11_lev[lev] = nullptr; Tau22_lev[lev] = nullptr; Tau33_lev[lev] = nullptr;
         Tau12_lev[lev] = nullptr; Tau21_lev[lev] = nullptr;
@@ -469,10 +475,11 @@ ERF::update_diffusive_arrays (int lev, const BoxArray& ba, const DistributionMap
         Tau23_lev[lev] = nullptr; Tau32_lev[lev] = nullptr;
         SFS_hfx1_lev[lev] = nullptr; SFS_hfx2_lev[lev] = nullptr; SFS_hfx3_lev[lev] = nullptr;
         SFS_diss_lev[lev] = nullptr;
+        SFS_qfx3_lev[lev] = nullptr;
     }
 
     if (l_use_kturb) {
-      eddyDiffs_lev[lev] = std::make_unique<MultiFab>( ba, dm, EddyDiff::NumDiffs, 1 );
+        eddyDiffs_lev[lev] = std::make_unique<MultiFab>( ba, dm, EddyDiff::NumDiffs, 1 );
         eddyDiffs_lev[lev]->setVal(0.0);
         if(l_use_ddorf) {
             SmnSmn_lev[lev] = std::make_unique<MultiFab>( ba, dm, 1, 0 );

--- a/Source/IO/ERF_Write1DProfiles_stag.cpp
+++ b/Source/IO/ERF_Write1DProfiles_stag.cpp
@@ -127,12 +127,12 @@ ERF::write_1D_profiles_stag(Real time)
                       Real thface = 0.5*(h_avg_th[k] + h_avg_th[k-1]);
                       Real pface  = 0.5*(h_avg_p[k]  + h_avg_p[k-1]);
                       Real uuface = 0.5*(h_avg_uu[k] + h_avg_uu[k-1]);
-                      Real uvface = 0.5*(h_avg_uv[k] + h_avg_uv[k-1]);
+                      //Real uvface = 0.5*(h_avg_uv[k] + h_avg_uv[k-1]);
                       Real vvface = 0.5*(h_avg_vv[k] + h_avg_vv[k-1]);
-                      Real w_cc   = 0.5*(h_avg_w[k-1]  + h_avg_w[k]);
-                      Real uw_cc  = 0.5*(h_avg_uw[k-1] + h_avg_uw[k]);
-                      Real vw_cc  = 0.5*(h_avg_vw[k-1] + h_avg_vw[k]);
-                      Real ww_cc  = 0.5*(h_avg_ww[k-1] + h_avg_ww[k]);
+                           w_cc   = 0.5*(h_avg_w[k-1]  + h_avg_w[k]);
+                           uw_cc  = 0.5*(h_avg_uw[k-1] + h_avg_uw[k]);
+                           vw_cc  = 0.5*(h_avg_vw[k-1] + h_avg_vw[k]);
+                           ww_cc  = 0.5*(h_avg_ww[k-1] + h_avg_ww[k]);
                       data_log2 << std::setw(datwidth) << std::setprecision(timeprecision) << time << " "
                                 << std::setw(datwidth) << std::setprecision(datprecision) << z << " "
                                 << h_avg_uu[k]   - h_avg_u[k]*h_avg_u[k]   << " " // u'u'
@@ -177,7 +177,7 @@ ERF::write_1D_profiles_stag(Real time)
                   Real thface = 1.5*h_avg_th[k-1] - 0.5*h_avg_th[k-2];
                   Real pface  = 1.5*h_avg_p[k-1]  - 0.5*h_avg_p[k-2];
                   Real uuface = 1.5*h_avg_uu[k-1] - 0.5*h_avg_uu[k-2];
-                  Real uvface = 1.5*h_avg_uv[k-1] - 0.5*h_avg_uv[k-2];
+                  //Real uvface = 1.5*h_avg_uv[k-1] - 0.5*h_avg_uv[k-2];
                   Real vvface = 1.5*h_avg_vv[k-1] - 0.5*h_avg_vv[k-2];
                   data_log2 << std::setw(datwidth) << std::setprecision(timeprecision) << time << " "
                             << std::setw(datwidth) << std::setprecision(datprecision) << k * dx[2] << " "

--- a/Source/Microphysics/FastEddy/FastEddy.H
+++ b/Source/Microphysics/FastEddy/FastEddy.H
@@ -94,7 +94,8 @@ public:
 
     // wrapper to do all the updating
     void
-    Advance (const amrex::Real& dt_advance, const SolverChoice& solverChoice) override
+    Advance (const amrex::Real& dt_advance,
+             const SolverChoice& /*solverChoice*/) override
     {
         dt = dt_advance;
 

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -119,7 +119,7 @@ public:
     // wrapper to do all the updating
     void
     Advance (const amrex::Real& dt_advance,
-             const SolverChoice& solverChoice) override
+             const SolverChoice& /*solverChoice*/) override
     {
         dt = dt_advance;
 

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -139,7 +139,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
 
     const bool use_moisture = (solverChoice.moisture_type != MoistureType::None);
     const bool use_most     = (most != nullptr);
-    const bool store_most_stress = most->store_fluxes();
+    const bool store_most_stress = (most != nullptr) ? most->store_fluxes() : false;
 
     const amrex::BCRec* bc_ptr   = domain_bcs_type_d.data();
     const amrex::BCRec* bc_ptr_h = domain_bcs_type.data();

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -139,6 +139,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
 
     const bool use_moisture = (solverChoice.moisture_type != MoistureType::None);
     const bool use_most     = (most != nullptr);
+    const bool store_most_stress = most->store_fluxes();
 
     const amrex::BCRec* bc_ptr   = domain_bcs_type_d.data();
     const amrex::BCRec* bc_ptr_h = domain_bcs_type.data();
@@ -237,13 +238,11 @@ void erf_slow_rhs_pre (int level, int finest_level,
             Box tbxxz = mfi.tilebox(IntVect(1,0,1));
             Box tbxyz = mfi.tilebox(IntVect(0,1,1));
 
-#ifdef ERF_EXPLICIT_MOST_STRESS
-            if (use_most) {
+            if (store_most_stress) {
                 // Don't overwrite modeled total stress value at boundary
-                tbxxz.setSmall(2,1);
-                tbxyz.setSmall(2,1);
+                if (tbxxz.smallEnd(2) == domain.smallEnd(2)) tbxxz.growLo(2,1);
+                if (tbxyz.smallEnd(2) == domain.smallEnd(2)) tbxyz.growLo(2,1);
             }
-#endif
 
             // We need a halo cell for terrain
              bxcc.grow(IntVect(1,1,0));


### PR DESCRIPTION
Major changes:

1. This is now runtime selectable. You can do so with `erf.most.store_fluxes = true`
2. The viewpoint is now that MOSTStress.H functions only compute and return the flux
3. ABLMost.cpp we now choose whether we populate the ghost cells with eta and the returned flux or if we use the new method with the gradient one cell above.
4. I hacked in q SFS_qfx3_lev for future work (it's kind of placeholder at the moment)

Things I **DIDN'T** do:
1. Remove the compilation flags and stuff for Gmake and Cmake